### PR TITLE
Google Fonts @import uses HTTPS

### DIFF
--- a/Nginx-Fancyindex-Theme/css/styles.css
+++ b/Nginx-Fancyindex-Theme/css/styles.css
@@ -1,4 +1,4 @@
-@import "http://fonts.googleapis.com/css?family=Open+Sans:400,300";
+@import "https://fonts.googleapis.com/css?family=Open+Sans:400,300";
 * {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
If you use HTTP, Chrome won't load the fonts from Google if you're viewing a directory listing behind HTTPS. Here's my one-character fix.