### PR TITLE
fixed paths for light and dark theme

### DIFF
--- a/Nginx-Fancyindex-Theme-dark/footer.html
+++ b/Nginx-Fancyindex-Theme-dark/footer.html
@@ -1,7 +1,7 @@
     <footer>
         Theme available on <a href="https://GitHub.com/Naereen/Nginx-Fancyindex-Theme">GitHub</a> by <a href="https://GitHub.com/Naereen">Naereen</a>, © 2015-17, released under <a href="https://lbesson.mit-license.org/">the MIT License</a>.
     </footer>
-    <script src="/Nginx-Fancyindex-Theme/addNginxFancyIndexForm.js"></script>
+    <script src="/Nginx-Fancyindex-Theme-dark/addNginxFancyIndexForm.js"></script>
 </body>
 </html>
 <!--

--- a/Nginx-Fancyindex-Theme-dark/header.html
+++ b/Nginx-Fancyindex-Theme-dark/header.html
@@ -5,7 +5,7 @@
         <meta http-equiv="x-ua-compatible" content="IE=edge">
         <title>Nginx Directory</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="/Nginx-Fancyindex-Theme/styles.css">
+        <link rel="stylesheet" href="/Nginx-Fancyindex-Theme-dark/styles.css">
     </head>
 <body>
 <!--

--- a/Nginx-Fancyindex-Theme-light/footer.html
+++ b/Nginx-Fancyindex-Theme-light/footer.html
@@ -1,7 +1,7 @@
     <footer>
         Theme available on <a href="https://GitHub.com/Naereen/Nginx-Fancyindex-Theme">GitHub</a> by <a href="https://GitHub.com/Naereen">Naereen</a>, © 2015-17, released under <a href="https://lbesson.mit-license.org/">the MIT License</a>.
     </footer>
-    <script src="/Nginx-Fancyindex-Theme/addNginxFancyIndexForm.js"></script>
+    <script src="/Nginx-Fancyindex-Theme-light/addNginxFancyIndexForm.js"></script>
 </body>
 </html>
 <!--

--- a/Nginx-Fancyindex-Theme-light/header.html
+++ b/Nginx-Fancyindex-Theme-light/header.html
@@ -5,7 +5,7 @@
         <meta http-equiv="x-ua-compatible" content="IE=edge">
         <title>Nginx Directory</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="/Nginx-Fancyindex-Theme/styles.css">
+        <link rel="stylesheet" href="/Nginx-Fancyindex-Theme-light/styles.css">
     </head>
 <body>
 <!--

--- a/fancyindex.conf
+++ b/fancyindex.conf
@@ -1,8 +1,8 @@
 fancyindex on;
 fancyindex_localtime on;
 fancyindex_exact_size off;
-fancyindex_header "/Nginx-Fancyindex-Theme/header.html";
-fancyindex_footer "/Nginx-Fancyindex-Theme/footer.html";
+fancyindex_header "/Nginx-Fancyindex-Theme-light/header.html";
+fancyindex_footer "/Nginx-Fancyindex-Theme-light/footer.html";
 fancyindex_ignore "examplefile.html"; # Ignored files will not show up in the directory listing, but will still be public. 
-fancyindex_ignore "Nginx-Fancyindex-Theme"; # Making sure folder where files are don't show up in the listing. 
+fancyindex_ignore "Nginx-Fancyindex-Theme-light"; # Making sure folder where files are don't show up in the listing. 
 fancyindex_name_length 255; # Maximum file name length in bytes, change as you like.


### PR DESCRIPTION
During the split to dark and light-theme some paths in the header an footer were wrong.
I tried to fix that, hopefully I haven't missed one.
