### PR TITLE
fix a render bug of tables in markdown

### DIFF
--- a/Nginx-Fancyindex-Theme-dark/footer.html
+++ b/Nginx-Fancyindex-Theme-dark/footer.html
@@ -6,7 +6,7 @@
     <script type="text/javascript" src="/Nginx-Fancyindex-Theme-dark/addNginxFancyIndexForm.js"></script>
     <script type="text/javascript" src="/Nginx-Fancyindex-Theme-dark/showdown.min.js"></script>
     <script type="text/javascript" defer>
-    var converter = new showdown.Converter();
+    var converter = new showdown.Converter({tables: true});
     $( "#raw_include_HEADER_md" ).load( "HEADER.md", function (){
         var elem = document.querySelector("#raw_include_HEADER_md");
         // strip leading whitespace so it isn't evaluated as code

--- a/Nginx-Fancyindex-Theme-light/footer.html
+++ b/Nginx-Fancyindex-Theme-light/footer.html
@@ -6,7 +6,7 @@
     <script type="text/javascript" src="/Nginx-Fancyindex-Theme-light/addNginxFancyIndexForm.js"></script>
     <script type="text/javascript" src="/Nginx-Fancyindex-Theme-light/showdown.min.js"></script>
     <script type="text/javascript" defer>
-        var converter = new showdown.Converter();
+        var converter = new showdown.Converter({tables: true});
         $( "#raw_include_HEADER_md" ).load( "HEADER.md", function (){
             var elem = document.querySelector("#raw_include_HEADER_md");
             // strip leading whitespace so it isn't evaluated as code


### PR DESCRIPTION
Hi, if the 'tables' option of 'showdown' is not turned on, tables in markdown files (README.md and HEADER.md) would not be correctly rendered.

Please merge the request or fix it. 