### PR TITLE
fix: swap incorrect Size and Last Modified labels in mobile view

### DIFF
--- a/Nginx-Fancyindex/styles.css
+++ b/Nginx-Fancyindex/styles.css
@@ -697,11 +697,11 @@ footer a {
         }
 
         td:nth-of-type(2):not([data-label])::before {
-                content: 'Last modified';
+                content: 'Size';
         }
 
         td:nth-of-type(3):not([data-label])::before {
-                content: 'Size';
+                content: 'Last modified';
         }
 
         td:nth-of-type(4):not([data-label])::before {


### PR DESCRIPTION
Hello, I switched the 'Size' and 'Last Modified' labels as they were appearing in the wrong order on mobile.

Thanks for this helpful project.